### PR TITLE
Account 계좌 관리 기능 추가

### DIFF
--- a/src/main/java/com/example/accountz/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/example/accountz/config/JpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.example.accountz.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+
+}

--- a/src/main/java/com/example/accountz/exception/GlobalException.java
+++ b/src/main/java/com/example/accountz/exception/GlobalException.java
@@ -21,6 +21,10 @@ public class GlobalException extends RuntimeException {
     this.errorCode = errorCode;
     this.errorMessage = errorCode.getDescription();
   }
+    @Override
+    public String getMessage() {
+        return this.errorMessage;
+    }
 }
 
 

--- a/src/main/java/com/example/accountz/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/accountz/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.example.accountz.type.ErrorCode;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/src/main/java/com/example/accountz/model/AccountDto.java
+++ b/src/main/java/com/example/accountz/model/AccountDto.java
@@ -1,0 +1,34 @@
+package com.example.accountz.model;
+
+import com.example.accountz.persist.entity.AccountEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccountDto {
+  private Long userId;
+  private String accountNumber;
+  private Long balance;
+
+  private LocalDateTime registeredAt;
+  private LocalDateTime unRegisteredAt;
+
+  public static AccountDto fromEntity(AccountEntity account){
+    return AccountDto.builder()
+        .userId(account.getId())
+        .accountNumber(account.getAccountNumber())
+        .balance(account.getBalance())
+        .registeredAt(account.getRegisteredAt())
+        .unRegisteredAt(account.getUnRegisteredAt())
+        .build();
+  }
+
+}

--- a/src/main/java/com/example/accountz/model/CreateAccountDto.java
+++ b/src/main/java/com/example/accountz/model/CreateAccountDto.java
@@ -1,0 +1,45 @@
+package com.example.accountz.model;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class CreateAccountDto {
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Request {
+    @NotNull
+    @Min(1)
+    private Long userId;
+
+    @NotNull
+    @Min(0)
+    private Long initialBalance;
+  }
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Response {
+    private Long userId;
+    private String accountNumber;
+    private LocalDateTime registeredAt;
+
+    public static Response from(AccountDto accountDto){
+      return Response.builder()
+          .userId(accountDto.getUserId())
+          .accountNumber(accountDto.getAccountNumber())
+          .registeredAt(accountDto.getRegisteredAt())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/example/accountz/model/DeleteAccountDto.java
+++ b/src/main/java/com/example/accountz/model/DeleteAccountDto.java
@@ -1,9 +1,6 @@
 package com.example.accountz.model;
 
-import com.example.accountz.security.JwtTokenExtract;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -13,6 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class DeleteAccountDto {
+
   @Getter
   @Setter
   @NoArgsConstructor
@@ -30,14 +28,15 @@ public class DeleteAccountDto {
   @AllArgsConstructor
   @Builder
   public static class Response {
+
     private Long userId;
     private String accountNumber;
     private LocalDateTime unRegisteredAt;
 
-    public static Response from(AccountDto accountDto){
-      Long userId = JwtTokenExtract.currentUser().getId();
+    public static Response from(AccountDto accountDto) {
+
       return Response.builder()
-          .userId(userId)
+          .userId(accountDto.getUserId())
           .accountNumber(accountDto.getAccountNumber())
           .unRegisteredAt(accountDto.getUnRegisteredAt())
           .build();

--- a/src/main/java/com/example/accountz/model/DeleteAccountDto.java
+++ b/src/main/java/com/example/accountz/model/DeleteAccountDto.java
@@ -1,0 +1,46 @@
+package com.example.accountz.model;
+
+import com.example.accountz.security.JwtTokenExtract;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class DeleteAccountDto {
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Request {
+
+    @NotBlank
+    @Size(min = 10, max = 10)
+    private String accountNumber;
+  }
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Response {
+    private Long userId;
+    private String accountNumber;
+    private LocalDateTime unRegisteredAt;
+
+    public static Response from(AccountDto accountDto){
+      Long userId = JwtTokenExtract.currentUser().getId();
+      return Response.builder()
+          .userId(userId)
+          .accountNumber(accountDto.getAccountNumber())
+          .unRegisteredAt(accountDto.getUnRegisteredAt())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/example/accountz/model/TransactionDto.java
+++ b/src/main/java/com/example/accountz/model/TransactionDto.java
@@ -1,0 +1,40 @@
+package com.example.accountz.model;
+
+
+import com.example.accountz.persist.entity.TransactionEntity;
+import com.example.accountz.type.TransactionResultType;
+import com.example.accountz.type.TransactionType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TransactionDto {
+
+  private String accountNumber;
+  private TransactionType transactionType;
+  private TransactionResultType transactionResultType;
+  private Long amount;
+  private Long balanceSnapshot;
+  private String transactionId;
+  private LocalDateTime transactedAt;
+
+  public static TransactionDto fromEntity(TransactionEntity transaction){
+    return TransactionDto.builder()
+        .accountNumber(transaction.getAccount().getAccountNumber())
+        .transactionType(transaction.getTransactionType())
+        .transactionResultType(transaction.getTransactionResultType())
+        .amount(transaction.getAmount())
+        .balanceSnapshot(transaction.getBalanceSnapshot())
+        .transactionId(transaction.getTransactionId())
+        .transactedAt(transaction.getTransactedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/example/accountz/model/UseBalanceDto.java
+++ b/src/main/java/com/example/accountz/model/UseBalanceDto.java
@@ -1,0 +1,57 @@
+package com.example.accountz.model;
+
+import com.example.accountz.type.TransactionResultType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class UseBalanceDto {
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Request {
+
+    @NotBlank
+    @Size(min=10, max=10)
+    private String accountNumber;
+
+    @NotNull
+    @Min(1)
+    @Max(1000_000_000)
+    private Long amount;
+  }
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Response {
+    private String accountNumber;
+    private TransactionResultType transactionResultType;
+    private String transactionId;
+    private Long amount;
+    private LocalDateTime transactionAt;
+
+
+    public static Response from(TransactionDto transactionDto) {
+      return Response.builder()
+          .accountNumber(transactionDto.getAccountNumber())
+          .transactionResultType(transactionDto.getTransactionResultType())
+          .transactionId(transactionDto.getTransactionId())
+          .amount(transactionDto.getAmount())
+          .transactionAt(transactionDto.getTransactedAt())
+          .build();
+    }
+  }
+
+}

--- a/src/main/java/com/example/accountz/model/UserDto.java
+++ b/src/main/java/com/example/accountz/model/UserDto.java
@@ -2,53 +2,58 @@ package com.example.accountz.model;
 
 import com.example.accountz.persist.entity.UserEntity;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
 public class UserDto {
 
-    @Data
-    public static class SignIn {
-        private String email;
-        private String password;
+  @Data
+  public static class SignIn {
+
+    private String email;
+    private String password;
+  }
+
+  @Data
+  public static class SignUp {
+
+    @NotBlank
+    @Size(min = 2, message = "이름은 두 글자 이상 입력해주세요")
+    private String name;
+
+    @NotNull
+    @NotBlank
+    @Email(message = "올바른 이메일 주소를 입력해주세요")
+    private String email;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    @JsonFormat(pattern = "MM/dd/yyyy")
+    @Past(message = "미래의 날짜는 불가능 합니다.")
+    private LocalDate birthDay;
+
+    @NotBlank
+    @Size(min = 8, message = "비밀번호는 8자리 이상 입력해주세요")
+    private String password;
+
+    private List<String> roles;
+
+    public UserEntity toEntity() {
+      return UserEntity.builder()
+          .name(this.name)
+          .email(this.email)
+          .birthDay(this.birthDay)
+          .password(this.password)
+          .roles(this.roles)
+          .build();
     }
-
-    @Data
-    public static class SignUp{
-        @NotBlank
-        @Size(min = 2, message = "이름은 두 글자 이상 입력해주세요")
-        private String name;
-
-        @NotNull
-        @NotBlank
-        @Email(message = "올바른 이메일 주소를 입력해주세요")
-        private String email;
-
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-        @JsonFormat(pattern = "MM/dd/yyyy")
-        @Past(message = "미래의 날짜는 불가능 합니다.")
-        private LocalDate birthDay;
-
-        @NotBlank
-        @Size(min = 8, message = "비밀번호는 8자리 이상 입력해주세요")
-        private String password;
-
-        private LocalDateTime createdAt = LocalDateTime.now();
-
-
-        public UserEntity toEntity(){
-            return UserEntity.builder()
-                    .name(this.name)
-                    .email(this.email)
-                    .birthDay(this.birthDay)
-                    .password(this.password)
-                    .createdAt(this.createdAt)
-                    .build();
-        }
-    }
+  }
 
 }

--- a/src/main/java/com/example/accountz/persist/entity/AccountEntity.java
+++ b/src/main/java/com/example/accountz/persist/entity/AccountEntity.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -24,6 +25,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @Entity
 @Getter
+@Setter
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/example/accountz/persist/entity/AccountEntity.java
+++ b/src/main/java/com/example/accountz/persist/entity/AccountEntity.java
@@ -1,6 +1,8 @@
 package com.example.accountz.persist.entity;
 
+import com.example.accountz.exception.GlobalException;
 import com.example.accountz.type.AccountStatus;
+import com.example.accountz.type.ErrorCode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
@@ -54,6 +56,14 @@ public class AccountEntity {
   private LocalDateTime createdAt;
   @LastModifiedDate
   private LocalDateTime updatedAt;
+
+  public void saveMoney(Long amount){
+    if(amount < 0){
+      throw new GlobalException(ErrorCode.NOT_MINUS_MONEY);
+    }
+    balance += amount;
+  }
+
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/com/example/accountz/persist/entity/AccountEntity.java
+++ b/src/main/java/com/example/accountz/persist/entity/AccountEntity.java
@@ -64,7 +64,13 @@ public class AccountEntity {
     balance += amount;
   }
 
+  public void useBalance(Long amount){
+    if (amount > balance){
+      throw new GlobalException(ErrorCode.AMOUNT_EXCEED_BALANCE);
+    }
+    balance -= amount;
 
+  }
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/com/example/accountz/persist/repository/AccountRepository.java
+++ b/src/main/java/com/example/accountz/persist/repository/AccountRepository.java
@@ -14,4 +14,6 @@ public interface AccountRepository
 
     Optional<AccountEntity> findFirstByOrderByIdDesc();
 
+    Optional<AccountEntity> findByAccountNumber(String AccountNumber);
+
 }

--- a/src/main/java/com/example/accountz/persist/repository/AccountRepository.java
+++ b/src/main/java/com/example/accountz/persist/repository/AccountRepository.java
@@ -1,10 +1,17 @@
 package com.example.accountz.persist.repository;
 
 import com.example.accountz.persist.entity.AccountEntity;
+import com.example.accountz.persist.entity.UserEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AccountRepository
         extends JpaRepository<AccountEntity, Long> {
+
+    Integer countByUser(UserEntity user);
+
+    Optional<AccountEntity> findFirstByOrderByIdDesc();
+
 }

--- a/src/main/java/com/example/accountz/security/Authority.java
+++ b/src/main/java/com/example/accountz/security/Authority.java
@@ -1,0 +1,6 @@
+package com.example.accountz.security;
+
+public enum Authority {
+  ROLE_USER,
+  ROLE_OWNER
+}

--- a/src/main/java/com/example/accountz/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/accountz/security/JwtAuthenticationFilter.java
@@ -1,10 +1,14 @@
 package com.example.accountz.security;
 
 
+import com.example.accountz.exception.ErrorResponse;
+import com.example.accountz.exception.GlobalException;
+import com.example.accountz.type.ErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,53 +19,55 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    public static final String TOKEN_HEADER = "Authorization";
-    public static final String TOKEN_PREFIX = "Bearer ";
+  public static final String TOKEN_HEADER = "Authorization";
+  public static final String TOKEN_PREFIX = "Bearer ";
 
-    private final TokenProvider tokenProvider;
+  private final TokenProvider tokenProvider;
 
 
-    private String resolveTokenFromRequest(HttpServletRequest request) {
-        String token = request.getHeader(TOKEN_HEADER);
+  private String resolveTokenFromRequest(HttpServletRequest request) {
+    String token = request.getHeader(TOKEN_HEADER);
 
-        if (!StringUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
-            return token.substring(TOKEN_PREFIX.length());
-        }
-        return null;
+    if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+      return token.substring(TOKEN_PREFIX.length());
+    }
+    return null;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String token = this.resolveTokenFromRequest(request);
+
+    if (token != null && this.tokenProvider.isBlacklisted(token)) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      response.setContentType("application/json");
+      String errorMessage = "{\"error\": \"Unauthorized\", \"message\": \"Your token is blacklisted.\"}";
+      response.getOutputStream().write(errorMessage.getBytes());
+      //throw new GlobalException(ErrorCode.WRONG_TOKEN);
+      // 이부분 콘솔에만 예외처리됨 -> 나중에 고쳐야함
     }
 
-    @Override
-    protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
-        String token = this.resolveTokenFromRequest(request);
+    if (StringUtils.hasText(token)
+        && this.tokenProvider.validateToken(token)) {
+      Authentication auth =
+          this.tokenProvider.getAuthentication(token);
 
-        // 토큰이 블랙리스트에 등록되었는지 확인
-        if (token != null && this.tokenProvider.isBlacklisted(token)) {
-            // 블랙리스트에 등록된 토큰이면 인증 실패 처리
-            response.setStatus(HttpStatus.UNAUTHORIZED.value());
-            return;
-        }
-
-        if (StringUtils.hasText(token)
-                && this.tokenProvider.validateToken(token)) {
-            Authentication auth =
-                    this.tokenProvider.getAuthentication(token);
-
-            SecurityContextHolder.getContext().setAuthentication(auth);
-            log.info(String.format(
-                    "[%s] -> %s",
-                    this.tokenProvider.getUsername(token),
-                    request.getRequestURI()));
-        }
-        filterChain.doFilter(request, response);
+      SecurityContextHolder.getContext().setAuthentication(auth);
+      log.info(String.format(
+          "[%s] -> %s",
+          this.tokenProvider.getUsername(token),
+          request.getRequestURI()));
     }
+    filterChain.doFilter(request, response);
+  }
+
+
 }

--- a/src/main/java/com/example/accountz/security/JwtTokenExtract.java
+++ b/src/main/java/com/example/accountz/security/JwtTokenExtract.java
@@ -1,25 +1,19 @@
 package com.example.accountz.security;
 
 import com.example.accountz.persist.entity.UserEntity;
-import com.example.accountz.service.UserService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-@RequiredArgsConstructor
+import org.springframework.stereotype.Component;
 
+@Component
 public class JwtTokenExtract {
 
-    private final UserService userService;
+  public UserEntity currentUser() {
+    Authentication authentication =
+        SecurityContextHolder.getContext().getAuthentication();
 
-    @Value("${spring.jwt.secret}")
-    private String secretKey;
-
-    public static UserEntity currentUser() {
-        Authentication authentication =
-                SecurityContextHolder.getContext().getAuthentication();
-        return (UserEntity) authentication.getPrincipal();
-    }
-
+    return (UserEntity) authentication.getPrincipal();
+  }
 
 }
+

--- a/src/main/java/com/example/accountz/security/JwtTokenExtract.java
+++ b/src/main/java/com/example/accountz/security/JwtTokenExtract.java
@@ -1,0 +1,25 @@
+package com.example.accountz.security;
+
+import com.example.accountz.persist.entity.UserEntity;
+import com.example.accountz.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+@RequiredArgsConstructor
+
+public class JwtTokenExtract {
+
+    private final UserService userService;
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    public static UserEntity currentUser() {
+        Authentication authentication =
+                SecurityContextHolder.getContext().getAuthentication();
+        return (UserEntity) authentication.getPrincipal();
+    }
+
+
+}

--- a/src/main/java/com/example/accountz/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/accountz/security/SecurityConfiguration.java
@@ -35,8 +35,15 @@ public class SecurityConfiguration {
                                 SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(
                         authorize -> authorize.requestMatchers(
-                                "/auth/**"
-                        ).permitAll())
+                                "/auth/sign-up",
+                                "/auth/log-in",
+                                "/auth/log-out"
+                                )
+                                .permitAll()
+                                .anyRequest()
+                                .authenticated()
+
+                )
                 .addFilterBefore(this.authenticationFilter
                         , UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/example/accountz/service/AccountService.java
+++ b/src/main/java/com/example/accountz/service/AccountService.java
@@ -26,10 +26,12 @@ public class AccountService {
 
   private final AccountRepository accountRepository;
   private final UserRepository userRepository;
+  private final JwtTokenExtract jwtTokenExtract;
+
 
   @Transactional
   public AccountDto createAccount() {
-    Long userId = JwtTokenExtract.currentUser().getId();
+    Long userId = jwtTokenExtract.currentUser().getId();
 
     UserEntity user = userRepository.findById(userId).orElseThrow(() ->
         new GlobalException(USER_NOT_FOUND));

--- a/src/main/java/com/example/accountz/service/AccountService.java
+++ b/src/main/java/com/example/accountz/service/AccountService.java
@@ -1,5 +1,8 @@
 package com.example.accountz.service;
 
+import static com.example.accountz.type.ErrorCode.ACCOUNT_NOT_FOUND;
+import static com.example.accountz.type.ErrorCode.USER_NOT_FOUND;
+
 import com.example.accountz.exception.GlobalException;
 import com.example.accountz.model.AccountDto;
 import com.example.accountz.persist.entity.AccountEntity;
@@ -11,6 +14,7 @@ import com.example.accountz.type.AccountStatus;
 import com.example.accountz.type.ErrorCode;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,9 +31,8 @@ public class AccountService {
   public AccountDto createAccount() {
     Long userId = JwtTokenExtract.currentUser().getId();
 
-    UserEntity user = userRepository.findById(userId)
-        .orElseThrow(() ->
-            new GlobalException(ErrorCode.USER_NOT_FOUND));
+    UserEntity user = userRepository.findById(userId).orElseThrow(() ->
+        new GlobalException(USER_NOT_FOUND));
 
     checkAccountLimit_5(user);
 
@@ -45,10 +48,8 @@ public class AccountService {
 
   private String createAccountNumber() {
     return accountRepository.findFirstByOrderByIdDesc()
-        .map(account -> (
-            Integer.parseInt(
-                account
-                    .getAccountNumber())) + 1 + "")
+        .map(account -> (Integer.parseInt(account.getAccountNumber())) + 1
+            + "")
         .orElse("1000000000");
   }
 
@@ -58,6 +59,38 @@ public class AccountService {
     }
   }
 
+  @Transactional
+  public AccountDto deleteAccount(Long userId, String accountNumber) {
+    UserEntity accountUser = userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+    AccountEntity account = accountRepository.findByAccountNumber(
+            accountNumber)
+        .orElseThrow(() -> new GlobalException(ACCOUNT_NOT_FOUND));
+
+    validateDeleteAccount(accountUser, account);
+
+    account.setAccountStatus(AccountStatus.UNREGISTERED);
+    account.setUnRegisteredAt(LocalDateTime.now());
+
+    // 불필요하지만 테스트를 위해 넣어둠
+    accountRepository.save(account);
+
+    return AccountDto.fromEntity(account);
+  }
+
+  private void validateDeleteAccount(
+      UserEntity accountUser, AccountEntity account)
+      throws GlobalException {
+    if (!Objects.equals(accountUser.getId(), account.getUser().getId())) {
+      throw new GlobalException(ErrorCode.USER_ACCOUNT_UNMATCHED);
+    }
+    if (account.getAccountStatus() == AccountStatus.UNREGISTERED) {
+      throw new GlobalException(ErrorCode.ACCOUNT_ALREADY_UNREGISTERED);
+    }
+    if (account.getBalance() > 0) {
+      throw new GlobalException(ErrorCode.BALANCE_NOT_EMPTY);
+    }
+  }
 
 }
 

--- a/src/main/java/com/example/accountz/service/AccountService.java
+++ b/src/main/java/com/example/accountz/service/AccountService.java
@@ -1,0 +1,63 @@
+package com.example.accountz.service;
+
+import com.example.accountz.exception.GlobalException;
+import com.example.accountz.model.AccountDto;
+import com.example.accountz.persist.entity.AccountEntity;
+import com.example.accountz.persist.entity.UserEntity;
+import com.example.accountz.persist.repository.AccountRepository;
+import com.example.accountz.persist.repository.UserRepository;
+import com.example.accountz.security.JwtTokenExtract;
+import com.example.accountz.type.AccountStatus;
+import com.example.accountz.type.ErrorCode;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class AccountService {
+
+  private final AccountRepository accountRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public AccountDto createAccount() {
+    Long userId = JwtTokenExtract.currentUser().getId();
+
+    UserEntity user = userRepository.findById(userId)
+        .orElseThrow(() ->
+            new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+    checkAccountLimit_5(user);
+
+    return AccountDto.fromEntity(accountRepository.save(
+        AccountEntity.builder()
+            .user(user)
+            .accountStatus(AccountStatus.ACTIVATED)
+            .accountNumber(createAccountNumber())
+            .balance(0L)
+            .registeredAt(LocalDateTime.now())
+            .build()));
+  }
+
+  private String createAccountNumber() {
+    return accountRepository.findFirstByOrderByIdDesc()
+        .map(account -> (
+            Integer.parseInt(
+                account
+                    .getAccountNumber())) + 1 + "")
+        .orElse("1000000000");
+  }
+
+  private void checkAccountLimit_5(UserEntity user) {
+    if (accountRepository.countByUser(user) >= 5) {
+      throw new GlobalException(ErrorCode.MAX_5_LIMIT_ACCOUNTS);
+    }
+  }
+
+
+}
+

--- a/src/main/java/com/example/accountz/service/AccountService.java
+++ b/src/main/java/com/example/accountz/service/AccountService.java
@@ -93,6 +93,5 @@ public class AccountService {
       throw new GlobalException(ErrorCode.BALANCE_NOT_EMPTY);
     }
   }
-
 }
 

--- a/src/main/java/com/example/accountz/service/TransactionService.java
+++ b/src/main/java/com/example/accountz/service/TransactionService.java
@@ -1,0 +1,116 @@
+package com.example.accountz.service;
+
+import com.example.accountz.exception.GlobalException;
+import com.example.accountz.model.TransactionDto;
+import com.example.accountz.persist.entity.AccountEntity;
+import com.example.accountz.persist.entity.TransactionEntity;
+import com.example.accountz.persist.entity.UserEntity;
+import com.example.accountz.persist.repository.AccountRepository;
+import com.example.accountz.persist.repository.TransactionRepository;
+import com.example.accountz.persist.repository.UserRepository;
+import com.example.accountz.type.AccountStatus;
+import com.example.accountz.type.ErrorCode;
+import com.example.accountz.type.TransactionResultType;
+import com.example.accountz.type.TransactionType;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+
+  private final AccountRepository accountRepository;
+  private final UserRepository userRepository;
+  private final TransactionRepository transactionRepository;
+
+  @Transactional
+  public TransactionDto saveMoney(
+      Long userId, String accountNumber, Long amount) {
+    UserEntity user = userRepository
+        .findById(userId)
+        .orElseThrow(() ->
+            new GlobalException(ErrorCode.USER_NOT_FOUND));
+    AccountEntity account = accountRepository
+        .findByAccountNumber(accountNumber)
+        .orElseThrow(() ->
+            new GlobalException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+    saveValidateMoney(amount, user, account);
+
+    account.saveMoney(amount);
+
+    return TransactionDto.fromEntity(
+        saveTransaction(
+            TransactionType.USE,
+            TransactionResultType.SUCCESS,
+            account,
+            amount
+        )
+    );
+
+  }
+
+  private static void saveValidateMoney(Long amount, UserEntity user,
+      AccountEntity account) {
+    if (!Objects.equals(
+        user.getId(), account.getUser().getId())) {
+      throw new GlobalException(ErrorCode.USER_ACCOUNT_UNMATCHED);
+    }
+    if (account.getAccountStatus() != AccountStatus.ACTIVATED) {
+      throw new GlobalException(
+          ErrorCode.ACCOUNT_ALREADY_UNREGISTERED
+      );
+    }
+    if (0 > amount) {
+      throw new GlobalException(ErrorCode.NOT_MINUS_MONEY);
+    }
+  }
+
+
+  private TransactionEntity saveTransaction(
+      TransactionType transactionType,
+      TransactionResultType transactionResultType,
+      AccountEntity account,
+      Long amount
+  ) {
+    return transactionRepository.save(
+        TransactionEntity.builder()
+            .transactionType(transactionType)
+            .transactionResultType(transactionResultType)
+            .account(account)
+            .amount(amount)
+            .balanceSnapshot(account.getBalance())
+            .transactionId(
+                UUID.randomUUID()
+                    .toString()
+                    .replace("-", ""))
+            .transactedAt(LocalDateTime.now())
+            .build()
+    );
+  }
+
+  @Transactional
+  public void saveFailedUseTransaction(
+      String accountNumber, Long amount) {
+    AccountEntity account =
+        accountRepository.findByAccountNumber(accountNumber)
+            .orElseThrow(() ->
+                new GlobalException(
+                    ErrorCode.ACCOUNT_NOT_FOUND)
+            );
+
+    saveTransaction(
+        TransactionType.USE,
+        TransactionResultType.FAIL,
+        account,
+        amount
+    );
+  }
+
+}

--- a/src/main/java/com/example/accountz/service/TransactionService.java
+++ b/src/main/java/com/example/accountz/service/TransactionService.java
@@ -47,10 +47,7 @@ public class TransactionService {
             TransactionType.USE,
             TransactionResultType.SUCCESS,
             account,
-            amount
-        )
-    );
-
+            amount));
   }
 
   private static void saveValidateMoney(Long amount, UserEntity user,
@@ -61,8 +58,7 @@ public class TransactionService {
     }
     if (account.getAccountStatus() != AccountStatus.ACTIVATED) {
       throw new GlobalException(
-          ErrorCode.ACCOUNT_ALREADY_UNREGISTERED
-      );
+          ErrorCode.ACCOUNT_ALREADY_UNREGISTERED);
     }
   }
 
@@ -72,8 +68,7 @@ public class TransactionService {
 
     UserEntity user = userRepository.findById(userId)
         .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
-    AccountEntity account = accountRepository.findByAccountNumber(
-            accountNumber)
+    AccountEntity account = accountRepository.findByAccountNumber(accountNumber)
         .orElseThrow(
             () -> new GlobalException(ErrorCode.ACCOUNT_NOT_FOUND));
 
@@ -97,8 +92,7 @@ public class TransactionService {
     }
     if (account.getAccountStatus() != AccountStatus.ACTIVATED) {
       throw new GlobalException(
-          ErrorCode.ACCOUNT_ALREADY_UNREGISTERED
-      );
+          ErrorCode.ACCOUNT_ALREADY_UNREGISTERED);
     }
     if (account.getBalance() < amount) {
       throw new GlobalException(ErrorCode.AMOUNT_EXCEED_BALANCE);
@@ -123,8 +117,7 @@ public class TransactionService {
                     .toString()
                     .replace("-", ""))
             .transactedAt(LocalDateTime.now())
-            .build()
-    );
+            .build());
   }
 
   @Transactional
@@ -138,8 +131,6 @@ public class TransactionService {
         TransactionType.USE,
         TransactionResultType.FAIL,
         account,
-        amount
-    );
+        amount);
   }
-
 }

--- a/src/main/java/com/example/accountz/service/TransactionService.java
+++ b/src/main/java/com/example/accountz/service/TransactionService.java
@@ -70,14 +70,12 @@ public class TransactionService {
   public TransactionDto useBalance(
       Long userId, String accountNumber, Long amount) {
 
-    UserEntity user = userRepository
-        .findById(userId)
-        .orElseThrow(() ->
-            new GlobalException(ErrorCode.USER_NOT_FOUND));
-    AccountEntity account = accountRepository
-        .findByAccountNumber(accountNumber)
-        .orElseThrow(() ->
-            new GlobalException(ErrorCode.ACCOUNT_NOT_FOUND));
+    UserEntity user = userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+    AccountEntity account = accountRepository.findByAccountNumber(
+            accountNumber)
+        .orElseThrow(
+            () -> new GlobalException(ErrorCode.ACCOUNT_NOT_FOUND));
 
     validateUseBalance(user, account, amount);
 
@@ -88,9 +86,7 @@ public class TransactionService {
             TransactionType.USE,
             TransactionResultType.SUCCESS,
             account,
-            amount
-        )
-    );
+            amount));
   }
 
   private void validateUseBalance(
@@ -135,9 +131,8 @@ public class TransactionService {
   public void saveFailedUseTransaction(
       String accountNumber, Long amount) {
     AccountEntity account = accountRepository.findByAccountNumber(
-            accountNumber)
-        .orElseThrow(
-            () -> new GlobalException(ErrorCode.ACCOUNT_NOT_FOUND));
+        accountNumber).orElseThrow(() ->
+        new GlobalException(ErrorCode.ACCOUNT_NOT_FOUND));
 
     saveTransaction(
         TransactionType.USE,

--- a/src/main/java/com/example/accountz/type/AccountStatus.java
+++ b/src/main/java/com/example/accountz/type/AccountStatus.java
@@ -2,6 +2,5 @@ package com.example.accountz.type;
 
 public enum AccountStatus {
     ACTIVATED,
-    UNACTIVATED,
     UNREGISTERED
 }

--- a/src/main/java/com/example/accountz/type/ErrorCode.java
+++ b/src/main/java/com/example/accountz/type/ErrorCode.java
@@ -12,6 +12,12 @@ public enum ErrorCode {
     WRONG_PASSWORD("잘못된 비밀번호 입니다."),
     WRONG_VALIDATION("상황에 맞게 내부 메세지에서 캐치 및 변경"),
 
+    // Token
+    WRONG_TOKEN("토큰 정보가 유효하지 않습니다."),
+
+    // Account
+    MAX_5_LIMIT_ACCOUNTS("최대 계좌 생성은 5개까지 입니다."),
+
     //
     INTERNAL_SERVER_ERROR("내부 서버 오류")
     ;

--- a/src/main/java/com/example/accountz/type/ErrorCode.java
+++ b/src/main/java/com/example/accountz/type/ErrorCode.java
@@ -21,6 +21,11 @@ public enum ErrorCode {
     USER_ACCOUNT_UNMATCHED("사용자와 계좌의 소유주가 다릅니다."),
     ACCOUNT_ALREADY_UNREGISTERED("계좌가 이미 해지되었습니다."),
     BALANCE_NOT_EMPTY("잔액이 있는 계좌는 해지할 수 없습니다."),
+
+    // Transaction
+    AMOUNT_EXCEED_BALANCE("거래금액이 잔액을 초과했습니다."),
+    NOT_MINUS_MONEY("0보다 작은 금액은 입금은 불가능합니다."),
+
     //
     INTERNAL_SERVER_ERROR("내부 서버 오류")
     ;

--- a/src/main/java/com/example/accountz/type/ErrorCode.java
+++ b/src/main/java/com/example/accountz/type/ErrorCode.java
@@ -17,7 +17,10 @@ public enum ErrorCode {
 
     // Account
     MAX_5_LIMIT_ACCOUNTS("최대 계좌 생성은 5개까지 입니다."),
-
+    ACCOUNT_NOT_FOUND("계좌가 없습니다."),
+    USER_ACCOUNT_UNMATCHED("사용자와 계좌의 소유주가 다릅니다."),
+    ACCOUNT_ALREADY_UNREGISTERED("계좌가 이미 해지되었습니다."),
+    BALANCE_NOT_EMPTY("잔액이 있는 계좌는 해지할 수 없습니다."),
     //
     INTERNAL_SERVER_ERROR("내부 서버 오류")
     ;

--- a/src/main/java/com/example/accountz/webController/AccountController.java
+++ b/src/main/java/com/example/accountz/webController/AccountController.java
@@ -1,0 +1,26 @@
+package com.example.accountz.webController;
+
+import com.example.accountz.model.CreateAccountDto;
+import com.example.accountz.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/account")
+@RequiredArgsConstructor
+public class AccountController {
+
+  private final AccountService accountService;
+
+  @PreAuthorize("hasRole('USER')")
+  @PostMapping("/user")
+  public CreateAccountDto.Response createAccount() {
+
+    return CreateAccountDto.Response.from(accountService.createAccount());
+  }
+}

--- a/src/main/java/com/example/accountz/webController/AccountController.java
+++ b/src/main/java/com/example/accountz/webController/AccountController.java
@@ -33,7 +33,7 @@ public class AccountController {
   @DeleteMapping("/user")
   public DeleteAccountDto.Response deleteAccount(
       @RequestBody @Valid DeleteAccountDto.Request request) {
-    
+
     return DeleteAccountDto.Response.from(accountService.deleteAccount(
         JwtTokenExtract.currentUser().getId(),
         request.getAccountNumber()));

--- a/src/main/java/com/example/accountz/webController/AccountController.java
+++ b/src/main/java/com/example/accountz/webController/AccountController.java
@@ -1,11 +1,16 @@
 package com.example.accountz.webController;
 
 import com.example.accountz.model.CreateAccountDto;
+import com.example.accountz.model.DeleteAccountDto;
+import com.example.accountz.security.JwtTokenExtract;
 import com.example.accountz.service.AccountService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,4 +28,15 @@ public class AccountController {
 
     return CreateAccountDto.Response.from(accountService.createAccount());
   }
+
+  @PreAuthorize("hasRole('USER')")
+  @DeleteMapping("/user")
+  public DeleteAccountDto.Response deleteAccount(
+      @RequestBody @Valid DeleteAccountDto.Request request) {
+    
+    return DeleteAccountDto.Response.from(accountService.deleteAccount(
+        JwtTokenExtract.currentUser().getId(),
+        request.getAccountNumber()));
+  }
+
 }

--- a/src/main/java/com/example/accountz/webController/AccountController.java
+++ b/src/main/java/com/example/accountz/webController/AccountController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
 
   private final AccountService accountService;
+  private final JwtTokenExtract jwtTokenExtract;
 
   @PreAuthorize("hasRole('USER')")
   @PostMapping("/user")
@@ -35,7 +36,7 @@ public class AccountController {
       @RequestBody @Valid DeleteAccountDto.Request request) {
 
     return DeleteAccountDto.Response.from(accountService.deleteAccount(
-        JwtTokenExtract.currentUser().getId(),
+        jwtTokenExtract.currentUser().getId(),
         request.getAccountNumber()));
   }
 

--- a/src/main/java/com/example/accountz/webController/TransactionController.java
+++ b/src/main/java/com/example/accountz/webController/TransactionController.java
@@ -1,0 +1,46 @@
+package com.example.accountz.webController;
+
+import com.example.accountz.exception.GlobalException;
+import com.example.accountz.model.UseBalanceDto;
+import com.example.accountz.security.JwtTokenExtract;
+import com.example.accountz.service.TransactionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/transaction")
+@RequiredArgsConstructor
+public class TransactionController {
+
+  private final TransactionService transactionService;
+
+  @PreAuthorize("hasRole('USER')")
+  @PostMapping("save-money")
+  public UseBalanceDto.Response userSaveMoney(
+      @Valid @RequestBody UseBalanceDto.Request request
+  ){
+    try {
+      return UseBalanceDto.Response.from(transactionService.saveMoney(
+          JwtTokenExtract.currentUser().getId(),
+          request.getAccountNumber(),
+          request.getAmount()));
+
+    } catch (GlobalException e) {
+      log.error("Failed to use balance.");
+
+      transactionService.saveFailedUseTransaction(
+          request.getAccountNumber(),
+          request.getAmount()
+      );
+      throw e;
+    }
+  }
+
+}

--- a/src/main/java/com/example/accountz/webController/TransactionController.java
+++ b/src/main/java/com/example/accountz/webController/TransactionController.java
@@ -25,7 +25,7 @@ public class TransactionController {
   @PostMapping("save-money")
   public UseBalanceDto.Response userSaveMoney(
       @Valid @RequestBody UseBalanceDto.Request request
-  ){
+  ) {
     try {
       return UseBalanceDto.Response.from(transactionService.saveMoney(
           JwtTokenExtract.currentUser().getId(),
@@ -33,7 +33,7 @@ public class TransactionController {
           request.getAmount()));
 
     } catch (GlobalException e) {
-      log.error("Failed to use balance.");
+      log.error("Failed to save balance.");
 
       transactionService.saveFailedUseTransaction(
           request.getAccountNumber(),
@@ -43,4 +43,24 @@ public class TransactionController {
     }
   }
 
+  @PreAuthorize("hasRole('USER')")
+  @PostMapping("withdraw")
+  public UseBalanceDto.Response useBalance(
+      @Valid @RequestBody UseBalanceDto.Request request
+  ) {
+    try {
+      return UseBalanceDto.Response.from(transactionService.useBalance(
+          JwtTokenExtract.currentUser().getId(),
+          request.getAccountNumber(),
+          request.getAmount()));
+
+    } catch (GlobalException e) {
+      log.error("Failed to use balance.");
+      transactionService.saveFailedUseTransaction(
+          request.getAccountNumber(),
+          request.getAmount()
+      );
+      throw e;
+    }
+  }
 }

--- a/src/main/java/com/example/accountz/webController/TransactionController.java
+++ b/src/main/java/com/example/accountz/webController/TransactionController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TransactionController {
 
   private final TransactionService transactionService;
+  private final JwtTokenExtract jwtTokenExtract;
 
   @PreAuthorize("hasRole('USER')")
   @PostMapping("save-money")
@@ -28,7 +29,7 @@ public class TransactionController {
   ) {
     try {
       return UseBalanceDto.Response.from(transactionService.saveMoney(
-          JwtTokenExtract.currentUser().getId(),
+          jwtTokenExtract.currentUser().getId(),
           request.getAccountNumber(),
           request.getAmount()));
 
@@ -50,7 +51,7 @@ public class TransactionController {
   ) {
     try {
       return UseBalanceDto.Response.from(transactionService.useBalance(
-          JwtTokenExtract.currentUser().getId(),
+          jwtTokenExtract.currentUser().getId(),
           request.getAccountNumber(),
           request.getAmount()));
 

--- a/src/test/java/com/example/accountz/service/AccountServiceTest.java
+++ b/src/test/java/com/example/accountz/service/AccountServiceTest.java
@@ -1,0 +1,159 @@
+package com.example.accountz.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.accountz.exception.GlobalException;
+import com.example.accountz.model.AccountDto;
+import com.example.accountz.persist.entity.AccountEntity;
+import com.example.accountz.persist.entity.UserEntity;
+import com.example.accountz.persist.repository.AccountRepository;
+import com.example.accountz.persist.repository.UserRepository;
+import com.example.accountz.security.JwtTokenExtract;
+import com.example.accountz.type.AccountStatus;
+import com.example.accountz.type.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class AccountServiceTest {
+
+  @Mock
+  private AccountRepository accountRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private JwtTokenExtract jwtTokenExtract;
+
+  @InjectMocks
+  private AccountService accountService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void createAccount_Success() {
+    // Given
+    Long userId = 1L;
+    UserEntity user = UserEntity.builder()
+        .id(userId)
+        .build();
+    AccountEntity savedAccountEntity = AccountEntity.builder()
+        .id(1L)
+        .user(user)
+        .accountStatus(AccountStatus.ACTIVATED)
+        .balance(0L)
+        .registeredAt(LocalDateTime.now())
+        .build();
+
+    when(jwtTokenExtract.currentUser()).thenReturn(user);
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(accountRepository.countByUser(user)).thenReturn(0);
+    when(accountRepository.save(any(AccountEntity.class))).thenAnswer(
+        invocation -> {
+          AccountEntity accountEntity = invocation.getArgument(0);
+          accountEntity.setId(1L);
+          return accountEntity;
+        });
+
+    // When
+    AccountDto createdAccount = accountService.createAccount();
+
+    // Then
+    assertEquals(AccountStatus.ACTIVATED,
+        savedAccountEntity.getAccountStatus());
+    assertEquals(0L, createdAccount.getBalance());
+    assertEquals(user.getId(), createdAccount.getUserId());
+    assertEquals(1, createdAccount.getUserId());
+    verify(accountRepository, times(1)).save(any(AccountEntity.class));
+  }
+
+  @Test
+  void createAccount_UserNotFound_ThrowsGlobalException() {
+    // Given
+    Long userId = 1L;
+    when(jwtTokenExtract.currentUser()).thenReturn(
+        UserEntity.builder().id(userId).build());
+    when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+    // When
+    GlobalException exception = assertThrows(GlobalException.class,
+        () -> accountService.createAccount());
+
+    // Then
+    assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    verify(accountRepository, never()).save(any(AccountEntity.class));
+  }
+
+  @Test
+  void deleteAccount_Success() {
+    // Given
+    Long userId = 1L;
+    String accountNumber = "1000000001";
+    UserEntity accountUser = UserEntity.builder().id(userId).build();
+    AccountEntity accountEntity = AccountEntity.builder()
+        .id(1L)
+        .user(accountUser)
+        .accountNumber(accountNumber)
+        .balance(0L)
+        .accountStatus(AccountStatus.ACTIVATED)
+        .build();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(accountUser));
+    when(accountRepository.findByAccountNumber(accountNumber)).thenReturn(Optional.of(accountEntity));
+
+    // When
+    AccountDto deletedAccount = accountService.deleteAccount(userId, accountNumber);
+
+    // Then
+    assertEquals(accountEntity.getId(), deletedAccount.getUserId());
+    assertEquals(accountEntity.getAccountNumber(), deletedAccount.getAccountNumber());
+    assertEquals(AccountStatus.UNREGISTERED, accountEntity.getAccountStatus());
+    verify(accountRepository, times(1)).save(accountEntity);
+  }
+
+  @Test
+  void deleteAccount_UserNotFound_ThrowsGlobalException() {
+    // Given
+    Long userId = 1L;
+    String accountNumber = "1000000001";
+    when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+    // When
+    GlobalException exception = assertThrows(GlobalException.class, () -> accountService.deleteAccount(userId, accountNumber));
+
+    // Then
+    assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    verify(accountRepository, never()).save(any(AccountEntity.class));
+  }
+
+  @Test
+  void deleteAccount_AccountNotFound_ThrowsGlobalException() {
+    // Given
+    Long userId = 1L;
+    String accountNumber = "1000000001";
+    when(userRepository.findById(userId)).thenReturn(Optional.of(UserEntity.builder().id(userId).build()));
+    when(accountRepository.findByAccountNumber(accountNumber)).thenReturn(Optional.empty());
+
+    // When
+    GlobalException exception = assertThrows(GlobalException.class, () -> accountService.deleteAccount(userId, accountNumber));
+
+    // Then
+    assertEquals(ErrorCode.ACCOUNT_NOT_FOUND, exception.getErrorCode());
+    verify(accountRepository, never()).save(any(AccountEntity.class));
+  }
+
+}

--- a/src/test/java/com/example/accountz/service/TransactionServiceTest.java
+++ b/src/test/java/com/example/accountz/service/TransactionServiceTest.java
@@ -1,0 +1,181 @@
+package com.example.accountz.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.accountz.model.TransactionDto;
+import com.example.accountz.persist.entity.AccountEntity;
+import com.example.accountz.persist.entity.TransactionEntity;
+import com.example.accountz.persist.entity.UserEntity;
+import com.example.accountz.persist.repository.AccountRepository;
+import com.example.accountz.persist.repository.TransactionRepository;
+import com.example.accountz.persist.repository.UserRepository;
+import com.example.accountz.type.AccountStatus;
+import com.example.accountz.type.TransactionResultType;
+import com.example.accountz.type.TransactionType;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionServiceTest {
+
+  @Mock
+  private AccountRepository accountRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private TransactionRepository transactionRepository;
+
+  @InjectMocks
+  private TransactionService transactionService;
+
+  @Test
+  void saveMoney_success() {
+    // Given
+    Long userId = 1L;
+    String accountNumber = "123456789";
+    Long amount = 10000L;
+
+    UserEntity user = UserEntity.builder()
+        .id(userId)
+        .build();
+    AccountEntity account = AccountEntity.builder()
+        .id(1L)
+        .balance(amount)
+        .accountNumber(accountNumber)
+        .user(user)
+        .accountStatus(AccountStatus.ACTIVATED)
+        .build();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(accountRepository.findByAccountNumber(accountNumber)).thenReturn(
+        Optional.of(account));
+    when(transactionRepository.save(
+        any(TransactionEntity.class))).thenReturn(
+        TransactionEntity.builder()
+            .id(1L)
+            .transactionType(TransactionType.USE)
+            .transactionResultType(TransactionResultType.SUCCESS)
+            .account(account)
+            .amount(amount)
+            .balanceSnapshot(account.getBalance() + amount)
+            .transactionId("1234567890")
+            .transactedAt(LocalDateTime.now())
+            .build()
+    );
+
+    // When
+    TransactionDto transactionDto = transactionService.saveMoney(userId,
+        accountNumber, amount);
+
+    // Then
+    verify(accountRepository, times(1))
+        .findByAccountNumber(accountNumber);
+    verify(userRepository, times(1)).findById(userId);
+    verify(transactionRepository, times(1)).save(
+        any(TransactionEntity.class));
+    assertThat(transactionDto.getAmount()).isEqualTo(amount);
+    assertThat(transactionDto.getTransactionResultType()).isEqualTo(
+        TransactionResultType.SUCCESS);
+  }
+
+  @Test
+  void useBalance_success() {
+    // Given
+    Long userId = 1L;
+    String accountNumber = "123456789";
+    Long amount = 10000L;
+
+    UserEntity user = UserEntity.builder()
+        .id(userId)
+        .build();
+    AccountEntity account = AccountEntity.builder()
+        .id(1L)
+        .balance(amount)
+        .accountNumber(accountNumber)
+        .user(user)
+        .accountStatus(AccountStatus.ACTIVATED)
+        .balance(20000L)
+        .build();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(accountRepository.findByAccountNumber(accountNumber)).thenReturn(
+        Optional.of(account));
+    when(transactionRepository.save(
+        any(TransactionEntity.class))).thenReturn(
+        TransactionEntity.builder()
+            .id(1L)
+            .transactionType(TransactionType.USE)
+            .transactionResultType(TransactionResultType.SUCCESS)
+            .account(account)
+            .amount(amount)
+            .balanceSnapshot(account.getBalance() - amount)
+            .transactionId("1234567890")
+            .transactedAt(LocalDateTime.now())
+            .build()
+    );
+
+    // When
+    TransactionDto transactionDto = transactionService.useBalance(userId,
+        accountNumber, amount);
+
+    // Then
+    verify(accountRepository, times(1))
+        .findByAccountNumber(accountNumber);
+    verify(userRepository, times(1)).findById(userId);
+    verify(transactionRepository, times(1)).save(
+        any(TransactionEntity.class));
+    assertThat(transactionDto.getAmount()).isEqualTo(amount);
+    assertThat(transactionDto.getTransactionResultType()).isEqualTo(
+        TransactionResultType.SUCCESS);
+  }
+
+  @Test
+  void saveFailedUseTransaction_success() {
+    // Given
+    String accountNumber = "123456789";
+    Long amount = 10000L;
+
+    AccountEntity account = AccountEntity.builder()
+        .id(1L)
+        .balance(amount)
+        .accountNumber(accountNumber)
+        .accountStatus(AccountStatus.ACTIVATED)
+        .build();
+
+    when(accountRepository.findByAccountNumber(accountNumber)).thenReturn(
+        Optional.of(account));
+    when(transactionRepository.save(
+        any(TransactionEntity.class))).thenReturn(
+        TransactionEntity.builder()
+            .id(1L)
+            .transactionType(TransactionType.USE)
+            .transactionResultType(TransactionResultType.FAIL)
+            .account(account)
+            .amount(amount)
+            .balanceSnapshot(account.getBalance())
+            .transactionId("1234567890")
+            .transactedAt(LocalDateTime.now())
+            .build()
+    );
+
+    // When
+    transactionService.saveFailedUseTransaction(accountNumber, amount);
+
+    // Then
+    verify(accountRepository, times(1))
+        .findByAccountNumber(accountNumber);
+    verify(transactionRepository, times(1)).save(
+        any(TransactionEntity.class));
+  }
+}

--- a/src/test/java/com/example/accountz/webController/AccountControllerTest.java
+++ b/src/test/java/com/example/accountz/webController/AccountControllerTest.java
@@ -1,0 +1,109 @@
+package com.example.accountz.webController;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.accountz.model.AccountDto;
+import com.example.accountz.persist.entity.UserEntity;
+import com.example.accountz.security.JwtTokenExtract;
+import com.example.accountz.security.TokenProvider;
+import com.example.accountz.service.AccountService;
+import com.example.accountz.service.UserService;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@Slf4j
+@WebMvcTest(AccountController.class)
+class AccountControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private AccountService accountService;
+
+  @MockBean
+  private UserService userService;
+
+  @MockBean
+  private TokenProvider tokenProvider;
+
+  @MockBean
+  private JwtTokenExtract jwtTokenExtract;
+
+  private UserEntity user;
+  private String accessToken;
+
+  @BeforeEach
+  void setUp() {
+    // 회원가입 및 토큰 생성
+    user = UserEntity.builder()
+        .id(1L)
+        .email("test@example.com")
+        .password("password")
+        .roles(List.of("ROLE_USER"))
+        .build();
+    given(tokenProvider.generateToken(user.getEmail()))
+        .willReturn("access_token");
+    accessToken = "Bearer access_token";
+
+  }
+
+  @Test
+  @WithMockUser(username = "test@example.com", roles = "USER")
+  void createAccountTest() throws Exception {
+    // given
+    AccountDto accountDto = AccountDto.builder()
+        .userId(1L)
+        .accountNumber("1000000001")
+        .balance(0L)
+        .registeredAt(LocalDateTime.now())
+        .build();
+
+    given(accountService.createAccount()).willReturn(accountDto);
+
+    UserDetails userDetails = user;
+    given(userService.loadUserByUsername(anyString())).willReturn(userDetails);
+
+    given(tokenProvider.getAuthentication(anyString())).willReturn(
+        new UsernamePasswordAuthenticationToken(
+            userDetails,"",userDetails.getAuthorities()));
+
+    // when
+    ResultActions resultActions = mockMvc.perform(post("/account/user")
+            .with(csrf())
+        .header("Authorization", accessToken)
+        .contentType(MediaType.APPLICATION_JSON));
+
+    // then
+    resultActions
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId")
+            .value(accountDto.getUserId()))
+        .andExpect(jsonPath("$.accountNumber")
+            .value(accountDto.getAccountNumber()))
+        .andExpect(jsonPath("$.registeredAt")
+            .isNotEmpty());
+
+    verify(accountService, times(1))
+        .createAccount();
+  }
+}

--- a/src/test/java/com/example/accountz/webController/TransactionControllerTest.java
+++ b/src/test/java/com/example/accountz/webController/TransactionControllerTest.java
@@ -1,0 +1,194 @@
+package com.example.accountz.webController;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import com.example.accountz.exception.GlobalException;
+import com.example.accountz.model.TransactionDto;
+import com.example.accountz.model.UseBalanceDto;
+import com.example.accountz.model.UseBalanceDto.Response;
+import com.example.accountz.persist.entity.AccountEntity;
+import com.example.accountz.persist.entity.TransactionEntity;
+import com.example.accountz.persist.entity.UserEntity;
+import com.example.accountz.persist.repository.TransactionRepository;
+import com.example.accountz.security.JwtTokenExtract;
+import com.example.accountz.security.TokenProvider;
+import com.example.accountz.service.TransactionService;
+import com.example.accountz.service.UserService;
+import com.example.accountz.type.AccountStatus;
+import com.example.accountz.type.ErrorCode;
+import com.example.accountz.type.TransactionResultType;
+import com.example.accountz.type.TransactionType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TransactionController.class)
+class TransactionControllerTest {
+
+  @MockBean
+  private TransactionService transactionService;
+
+  @MockBean
+  private JwtTokenExtract jwtTokenExtract;
+
+  @MockBean
+  private TokenProvider tokenProvider;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private UserService userService;
+
+  @MockBean
+  private TransactionRepository transactionRepository;
+
+  private UserEntity user;
+  private String accessToken;
+
+  @BeforeEach
+  void setUp() {
+    // 회원가입 및 토큰 생성
+    user = UserEntity.builder()
+        .id(1L)
+        .email("test@example.com")
+        .password("password")
+        .roles(List.of("ROLE_USER"))
+        .build();
+    given(tokenProvider.generateToken(user.getEmail()))
+        .willReturn("access_token");
+    accessToken = "Bearer access_token";
+    UserDetails userDetails = user;
+    given(userService.loadUserByUsername(anyString())).willReturn(
+        userDetails);
+
+    given(tokenProvider.getAuthentication(anyString())).willReturn(
+        new UsernamePasswordAuthenticationToken(
+            userDetails, "", userDetails.getAuthorities()));
+    given(jwtTokenExtract.currentUser()).willReturn(user);
+
+  }
+
+  @Test
+  @WithMockUser(username = "test@example.com", roles = "USER")
+  void userSaveMoney() throws Exception {
+    //given
+    Long userId = user.getId();
+    String accountNumber = "1000000001";
+    Long amount = 1000L;
+    LocalDateTime localDateTime = LocalDateTime.of(
+        12, 12, 12, 12, 12, 12);
+    given(transactionService.saveMoney(
+        anyLong(), anyString(), anyLong()))
+        .willReturn(TransactionDto.builder()
+            .accountNumber(accountNumber)
+            .transactionType(TransactionType.USE)
+            .transactionResultType(
+                TransactionResultType.SUCCESS)
+            .amount(amount)
+            .transactionId("transactionIdForCancel")
+            .balanceSnapshot(5000L)
+            .transactedAt(localDateTime)
+            .build());
+
+    // When
+    UseBalanceDto.Request request = new UseBalanceDto.Request(
+        accountNumber, amount);
+    ResultActions resultActions = mockMvc.perform(
+        post("/transaction/save-money")
+            .with(csrf())
+            .header("Authorization", accessToken)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)));
+
+    // Then
+    resultActions
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.accountNumber").value(accountNumber))
+        .andExpect(jsonPath("$.transactionResultType").value(
+            TransactionResultType.SUCCESS.toString()))
+        .andExpect(jsonPath("$.transactionId").exists())
+        .andExpect(jsonPath("$.transactionAt")
+            .value(localDateTime.toString()));
+
+    verify(transactionService, times(1))
+        .saveMoney(userId, accountNumber,
+            amount);
+  }
+
+  @Test
+  @WithMockUser(username = "test@example.com", roles = "USER")
+  void useBalance() throws Exception {
+    //given
+    Long userId = user.getId();
+    String accountNumber = "1000000001";
+    Long amount = 1000L;
+    LocalDateTime localDateTime = LocalDateTime.of(
+        12, 12, 12, 12, 12, 12);
+    given(transactionService.useBalance(
+        anyLong(), anyString(), anyLong()))
+        .willReturn(TransactionDto.builder()
+            .accountNumber(accountNumber)
+            .transactionType(TransactionType.USE)
+            .transactionResultType(
+                TransactionResultType.SUCCESS)
+            .amount(amount)
+            .transactionId("transactionIdForCancel")
+            .balanceSnapshot(500L)
+            .transactedAt(localDateTime)
+            .build());
+
+    // When
+    UseBalanceDto.Request request = new UseBalanceDto.Request(
+        accountNumber, amount);
+    ResultActions resultActions = mockMvc.perform(
+        post("/transaction/withdraw")
+            .with(csrf())
+            .header("Authorization", accessToken)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)));
+
+    // Then
+    resultActions
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.accountNumber").value(accountNumber))
+        .andExpect(jsonPath("$.transactionResultType").value(
+            TransactionResultType.SUCCESS.toString()))
+        .andExpect(jsonPath("$.transactionId").exists())
+        .andExpect(jsonPath("$.transactionAt")
+            .value(localDateTime.toString()));
+
+    verify(transactionService, times(1))
+        .useBalance(userId, accountNumber,
+            amount);
+  }
+}

--- a/src/test/java/com/example/accountz/webController/UserControllerTest.java
+++ b/src/test/java/com/example/accountz/webController/UserControllerTest.java
@@ -91,7 +91,7 @@ class UserControllerTest {
     @WithMockUser
     @Test
     @DisplayName("로그인 성공")
-    void signIn()throws Exception {
+    void logIn()throws Exception {
         // Given
 
         UserDto.SignIn signInRequest = new UserDto.SignIn();
@@ -112,12 +112,12 @@ class UserControllerTest {
                 .willReturn(token);
         //when
         //then
-        mockMvc.perform(post("/auth/sign-in")
+        mockMvc.perform(post("/auth/log-in")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 signInRequest)))
-                //.andDo(print())
+                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title")
                         .value("Token"))


### PR DESCRIPTION
# 계좌 관리 기능
- jwt 토큰을 통해 유저확인
  - 테스트 코드 작성시 jwt 토큰 추출을 static 메서드로 사용 
  - -> 테스트코드로 작성시 안티패턴 -> static으로 사용 부적절
  - -> 해당 기능을 컴포넌트로 만들어 의존성 주입으로 변경

## 계좌 생성
  - jwt 토큰으로 유저 정보 확인
  - 개인당 계좌 최대 5개 보유
  - 맨 초기유저 -> 계좌번호 1000000000 로 시작 -> 그 이후 계좌 생성은 +1로 카운팅
  
## 계좌 삭제(해지)
  - jwt 토큰으로 유저 정보 확인
  - 계좌 잔액 0원인지 확인
  - 계좌 상태 비활성화 -> UNREGISTERED 변경
  - 비활성화 시점 저장

## 금액 인출
  - jwt 토큰으로 유저 정보 확인
  - 트랜젝션 실패할 경우 데이터 저장
  - 출금요청 금액이 계좌 잔액보다 많을 경우 인출 불가
  - 음수 불가
  - 해지된 계좌일 경우 예외처리
  - jwt 토큰 정보와 계좌번호 일치 조회 
  - 트랜젝션 엔티티에 데이터 관리 -> 트랜젝션 성공처리 여부

## 금액입금
  - jwt 토큰으로 유저 정보 확인
  - 트랜젝션 실패할 경우 데이터 저장
  - 음수 불가
  - 해지된 계좌일 경우 예외처리
  - jwt 토큰 정보와 계좌번호 일치 조회 
  - 트랜젝션 엔티티에 데이터 관리 -> 트랜젝션 성공처리 여부